### PR TITLE
KCL 1.2.1: Add support for configuring DynamoDB endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 AwsCredentials.properties
+*.swp

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -96,6 +96,7 @@ public class KinesisClientLibConfiguration {
     private String applicationName;
     private String streamName;
     private String kinesisEndpoint;
+    private String dynamoDBEndpoint;
     private InitialPositionInStream initialPositionInStream;
     private AWSCredentialsProvider kinesisCredentialsProvider;
     private AWSCredentialsProvider dynamoDBCredentialsProvider;
@@ -153,7 +154,7 @@ public class KinesisClientLibConfiguration {
             AWSCredentialsProvider dynamoDBCredentialsProvider,
             AWSCredentialsProvider cloudWatchCredentialsProvider,
             String workerId) {
-        this(applicationName, streamName, null, InitialPositionInStream.LATEST, kinesisCredentialsProvider,
+        this(applicationName, streamName, null, null, InitialPositionInStream.LATEST, kinesisCredentialsProvider,
                 dynamoDBCredentialsProvider, cloudWatchCredentialsProvider, DEFAULT_FAILOVER_TIME_MILLIS, workerId,
                 DEFAULT_MAX_RECORDS, DEFAULT_IDLETIME_BETWEEN_READS_MILLIS,
                 DEFAULT_DONT_CALL_PROCESS_RECORDS_FOR_EMPTY_RECORD_LIST, DEFAULT_PARENT_SHARD_POLL_INTERVAL_MILLIS,
@@ -169,6 +170,7 @@ public class KinesisClientLibConfiguration {
      *        can assist with troubleshooting (e.g. distinguish requests made by separate applications).
      * @param streamName Name of the Kinesis stream
      * @param kinesisEndpoint Kinesis endpoint
+     * @param dynamoDBEndpoint DynamoDB endpoint
      * @param initialPositionInStream One of LATEST or TRIM_HORIZON. The KinesisClientLibrary will start fetching
      *        records from that location in the stream when an application starts up for the first time and there
      *        are no checkpoints. If there are checkpoints, then we start from the checkpoint position.
@@ -202,6 +204,7 @@ public class KinesisClientLibConfiguration {
     public KinesisClientLibConfiguration(String applicationName,
             String streamName,
             String kinesisEndpoint,
+            String dynamoDBEndpoint,
             InitialPositionInStream initialPositionInStream,
             AWSCredentialsProvider kinesisCredentialsProvider,
             AWSCredentialsProvider dynamoDBCredentialsProvider,
@@ -235,6 +238,7 @@ public class KinesisClientLibConfiguration {
         this.applicationName = applicationName;
         this.streamName = streamName;
         this.kinesisEndpoint = kinesisEndpoint;
+        this.dynamoDBEndpoint = dynamoDBEndpoint;
         this.initialPositionInStream = initialPositionInStream;
         this.kinesisCredentialsProvider = kinesisCredentialsProvider;
         this.dynamoDBCredentialsProvider = dynamoDBCredentialsProvider;
@@ -378,6 +382,13 @@ public class KinesisClientLibConfiguration {
     }
 
     /**
+     * @return DynamoDB endpoint
+     */
+    public String getDynamoDBEndpoint() {
+        return dynamoDBEndpoint;
+    }
+
+    /**
      * @return the initialPositionInStream
      */
     public InitialPositionInStream getInitialPositionInStream() {
@@ -462,6 +473,15 @@ public class KinesisClientLibConfiguration {
      */
     public KinesisClientLibConfiguration withKinesisEndpoint(String kinesisEndpoint) {
         this.kinesisEndpoint = kinesisEndpoint;
+        return this;
+    }
+
+    /**
+     * @param dynamoDBEndpoint DynamoDB endpoint
+     * @return KinesisClientLibConfiguration
+     */
+    public KinesisClientLibConfiguration withDynamoDBEndpoint(String dynamoDBEndpoint) {
+        this.dynamoDBEndpoint = dynamoDBEndpoint;
         return this;
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -219,6 +219,11 @@ public class Worker implements Runnable {
             dynamoDBClient.setRegion(region);
             LOG.debug("The region of Amazon DynamoDB client has been set to " + config.getRegionName());
         }
+        // If a dynamoDB endpoint was explicitly specified, use it to set the DynamoDB endpoint.
+        if (config.getDynamoDBEndpoint() != null) {
+            dynamoDBClient.setEndpoint(config.getDynamoDBEndpoint());
+            LOG.debug("The endpoint of Amazon DynamoDB client has been set to " + config.getDynamoDBEndpoint());
+        }
         // If a kinesis endpoint was explicitly specified, use it to set the region of kinesis.
         if (config.getKinesisEndpoint() != null) {
             kinesisClient.setEndpoint(config.getKinesisEndpoint());


### PR DESCRIPTION
Adding a new field named `dynamoDBEndpoint` to the .properties file
that gets passed into the KCL multi-lang daemon. We need this ability
to point the KCL worker at a local instance of DynamoDB rather than in
AWS.
